### PR TITLE
v1.2 release

### DIFF
--- a/AzNetworkDiagram.psd1
+++ b/AzNetworkDiagram.psd1
@@ -12,7 +12,7 @@
     RootModule = 'AzNetworkDiagram.psm1'
     
     # Version number of this module.
-    ModuleVersion = '1.1.4'
+    ModuleVersion = '1.2'
     
     # Supported PSEditions
     # CompatiblePSEditions = @()
@@ -107,7 +107,7 @@
             # IconUri = ''
     
     # ReleaseNotes of this module
-             ReleaseNotes = 'v1.1.4 release'
+             ReleaseNotes = 'v1.2 release'
     
     # Prerelease string of this module
             # Prerelease = ''

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ An example [ADO pipeline YAML file](https://github.com/dan-madsen/AzNetworkDiagr
 ---
 
 # Changelog (since v1.0.1)
-## v1.2 (not released to PSGallery yet)
+## v1.2
 - New support for
   - Backup Vaults (not to be confused with Recovery Service Vaults below!)
     - References to Storage Accounts blobs/containers, PostgreSQL, etc...


### PR DESCRIPTION
## v1.2
- New support for
  - Backup Vaults (not to be confused with Recovery Service Vaults below!)
    - References to Storage Accounts blobs/containers, PostgreSQL, etc...
  - Recovery Service Vaults
    - References to VMs, MSSQL in VMs and Azure File Shares
  - Storage account/Azure File Share
  - Storage account/Container
  - Azure Container Registry - added repositories to diagram
  - Azure VMware Solution
- Changed parameters for Mangement Groups
  - EnableMgmtGroups removed, rarely a case where it would make sense to have mangement groups in a diagram with everything else. Utilize [-OnlyMgmtGroups $true] for management groups overview moving forward.
- New parameters
  - All non-core network resource, now have a corrosponding -Skip option. A few examples:
    - -SkipSA $true
    - -SkipVM $true
    - Use tab completion for a full list
- New features
  - NAT GW
    - Link addedd
  - Routes Tables
    - Routes are now sorted by Address Prefix
    - Route names are now part of the output
- Bugs fixed
  - Azure Firewall parsing when in VNet (ie. not vWAN configurations)
  - NAT Gateway: Public IP Prefixes are now showing correctly
  - Express Routes circuits are now validated prior to making links, to avoid non-sense in the output